### PR TITLE
Use Existing App Stake amount

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -27,7 +27,7 @@ async function main() {
     }
 
     const chainsStaked = (await askQuestion("Enter the chains you wish to stake, i.e: 0007,0021,0008: ")).split(",").map(s=>s.trim())
-    const amountToStake = await askQuestion("Enter the amount of uPOKT you wish to stake, i.e: 100000000: ")
+    const amountToStake = await askQuestion("Enter the amount of uPOKT you wish to stake, i.e: 100000000 (use -1 to use existing app stake amount): ")
 
     const isTestnet = (await askQuestionWithExpectedOutput("Is this for testnet?, i.e: yes/no: ", ["yes", "no"])) === "yes"
 

--- a/src/pokt/appStakeTxs.ts
+++ b/src/pokt/appStakeTxs.ts
@@ -12,6 +12,7 @@ import {getPoktProvider} from "../di";
 export async function appStakeRetry(appPrivateKey: string, retryAttempts = 10, testnet:boolean,  stakeAmount: string, chains: string[]): Promise<string> {
     const signer = await KeyManager.fromPrivateKey(appPrivateKey);
 
+
     const transactionBuilder = new TransactionBuilder({
         provider: getPoktProvider(),
         signer,
@@ -19,11 +20,16 @@ export async function appStakeRetry(appPrivateKey: string, retryAttempts = 10, t
     });
 
 
+    if (stakeAmount == "-1") {
+        const app = await getPoktProvider().getApp({address: signer.getAddress()})
+        stakeAmount = app.stakedTokens
+    }
+
     console.log("Attempting to stake app: ", signer.getAddress());
     const actionMsg = transactionBuilder.appStake({
         appPubKey: signer.getPublicKey(),
         chains: chains,
-        amount: stakeAmount,
+        amount: stakeAmount
     });
 
     let error: any;


### PR DESCRIPTION
Updating app stakes can be annoying to specify the number of pokt to stake, esepcially since the number of pokt staked barely changes after the initial stake. So I added a functionality to pass in "-1" and it will grab the existing app stake amount and use that amount.